### PR TITLE
Add domain and output directory CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # wrf-figures-svr
-O script oper_plot_wrf.py gera 7 figuras para cada dado do WRF. O script usa os arquivos wrfout* do domínio d02 apenas. O script utiliza o ano e dia juliano corrente para acessar o diretório onde estão os dados do WRF, e gera figuras no diretório ano/dia_juliano/. 
-***O caminho dos dados e das figuras deve ser ajustado nas linhas 114-115***
+O script `oper_plot_wrf.py` gera 7 figuras para cada saída do WRF. Por padrão, os arquivos `wrfout*` do domínio `d01` são utilizados, a data atual é empregada para localizar os dados e as figuras são salvas no diretório `figures/ano/dia_juliano` relativo ao repositório.
+
+Esses valores padrão podem ser substituídos pela interface de linha de comando:
+
+```
+python oper_plot_wrf.py --dominio d02 --output-dir /caminho/para/figuras --raw-dir /caminho/para/wrf
+```
 
 O script também usa imagemagick para cortar as bordas brancas das figuras.
 
-Os arquivos no diretório arquivos_auxiliares contêm escalas de cores e shapefiles que são usados em algumas figuras.
+Os arquivos no diretório `arquivos_auxiliares` contêm escalas de cores e shapefiles que são usados em algumas figuras.
 
-O ambiente python utilizado nas plotagens está no arquivo environment.yml
+O ambiente python utilizado nas plotagens está no arquivo `environment.yml`.

--- a/wrf_figures/arguments.py
+++ b/wrf_figures/arguments.py
@@ -52,6 +52,23 @@ def parse_arguments(argv: Iterable[str] | None = None) -> argparse.Namespace:
             "utiliza a convenção padrão em /storagefapesp/data/models/wrf/RAW."
         ),
     )
+    parser.add_argument(
+        "--dominio",
+        choices=("d01", "d02", "d03"),
+        default="d01",
+        help=(
+            "Domínio do modelo WRF a ser utilizado (d01, d02 ou d03). Quando não informado, "
+            "utiliza d01."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        help=(
+            "Diretório onde as figuras serão salvas. Quando não informado, utiliza o "
+            "padrão figures/ano/dia_juliano relativo ao repositório."
+        ),
+    )
     return parser.parse_args(argv)
 
 

--- a/wrf_figures/cli.py
+++ b/wrf_figures/cli.py
@@ -56,6 +56,7 @@ def build_auxiliary_paths() -> tuple[Path, Path, Path]:
 def orchestrate_plots(
     raw_dir: Path,
     figures_dir: Path,
+    domain: str,
     config: PlotConfig,
     precip_levels: Iterable[float],
     precip_colormap: ListedColormap,
@@ -67,8 +68,6 @@ def orchestrate_plots(
     datacrs: ccrs.CRS,
     mapcrs: ccrs.CRS,
 ) -> None:
-    domain = "d01"
-
     for fcsth in FCSTHS:
         metadata = build_forecast_metadata(init_datetime, fcsth)
         dataset_path = raw_dir / f"wrfout_{domain}_{metadata.valid_datetime:%Y-%m-%d_%H}:00:00"
@@ -160,13 +159,16 @@ def main(argv: Iterable[str] | None = None) -> None:
     target_date = args.rodada or dt.datetime.today().date()
     raw_dir = resolve_raw_directory(args.raw_dir, target_date)
 
-    figures_dir = (
-        PROJECT_ROOT
-        / ".."
-        / "figures"
-        / f"{target_date.year}"
-        / f"{target_date.timetuple().tm_yday:03d}"
-    ).resolve()
+    if args.output_dir:
+        figures_dir = Path(args.output_dir).expanduser().resolve()
+    else:
+        figures_dir = (
+            PROJECT_ROOT
+            / ".."
+            / "figures"
+            / f"{target_date.year}"
+            / f"{target_date.timetuple().tm_yday:03d}"
+        ).resolve()
     ensure_directory(figures_dir)
 
     _, colors_dir, crepdecs_path = build_auxiliary_paths()
@@ -183,6 +185,7 @@ def main(argv: Iterable[str] | None = None) -> None:
     orchestrate_plots(
         raw_dir=raw_dir,
         figures_dir=figures_dir,
+        domain=args.dominio,
         config=config,
         precip_levels=precip_levels,
         precip_colormap=precip_colormap,


### PR DESCRIPTION
## Summary
- add command line options to select the WRF domain and figures output directory
- update orchestration logic to use the chosen domain and create the requested folder structure
- document the new parameters and defaults in the README

## Testing
- python -m compileall wrf_figures

------
https://chatgpt.com/codex/tasks/task_b_68cc02dfe75883258713167eed8f89f8